### PR TITLE
A case illustrating dropping fetched data when consumer actor is shared

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -124,7 +124,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
   val pollMsg = Poll(this, periodic = true)
   val delayedPollMsg = Poll(this, periodic = false)
   def pollTimeout() = settings.pollTimeout
-  def pollInterval() = settings.pollInterval
+  def pollInterval() = 10.minutes
 
   var currentPollTask: Cancellable = _
 
@@ -293,7 +293,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
   }
 
   def scheduleFirstPollTask(): Unit =
-    if (currentPollTask == null) currentPollTask = schedulePollTask()
+    context.system.scheduler.scheduleOnce(50.millis, self, pollMsg)(context.dispatcher)
 
   def schedulePollTask(): Cancellable =
     context.system.scheduler.scheduleOnce(pollInterval(), self, pollMsg)(context.dispatcher)

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -13,6 +13,7 @@
 
     <logger name="kafka" level="WARN"/>
     <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" level="DEBUG"/>
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
 


### PR DESCRIPTION
Just a simple test case illustrating that fetched data can be dropped despite the absence of periodic fetches in cases when consumer actor is shared.